### PR TITLE
Fix variable name typo for search result count in SearchPage

### DIFF
--- a/src/components/Search/SearchPage.tsx
+++ b/src/components/Search/SearchPage.tsx
@@ -2,14 +2,14 @@ import {SearchContainer} from "./SearchContainer.tsx";
 import {SearchResultContainer} from "./SearchResultContainer.tsx";
 
 function SearchPage(){
-    const searchResultcount:number = 0;
+    const searchResultCount:number = 0;
 
     return(
         <section className="search-page">
             <p className="page-title">Book Search</p>
             <SearchContainer/>
             <SearchResultContainer
-                resultCount={searchResultcount}
+                resultCount={searchResultCount}
             />
 
         </section>


### PR DESCRIPTION
This pull request makes a minor change to the `SearchPage` component to correct a variable name typo, improving code readability and consistency.

- Renamed the `searchResultcount` variable to `searchResultCount` and updated its usage in the `SearchResultContainer` prop.