### PR TITLE
fix(bookcase): use dedicated zone and index fields from bookcase API …

### DIFF
--- a/src/pages/bookcase/ViewBookcasesPage.tsx
+++ b/src/pages/bookcase/ViewBookcasesPage.tsx
@@ -17,7 +17,7 @@ function ViewBookcasesPage() {
 		})
 			.then((response) => response.json())
 			.then((data) => {
-				console.log(data);
+				console.log("Fetched bookcases:", data);
 				setBookcases(data);
 			});
 	}
@@ -56,8 +56,8 @@ function ViewBookcasesPage() {
 								key={bookcase.bookcaseId}
 								bookcaseId={bookcase.bookcaseId}
 								location={bookcase?.location}
-								zone={bookcase?.bookcaseLabel.split(":")[0]}
-								identifier={bookcase?.bookcaseLabel.split(":")[1]}
+								zone={bookcase?.zone}
+								identifier={bookcase?.index}
 								capacity={bookcase?.bookCapacity}
 							></BookcaseCard>
 						</Link>


### PR DESCRIPTION
This pull request makes minor improvements to the `ViewBookcasesPage` component. The changes include updating how bookcase data is logged to the console and adjusting how the `zone` and `identifier` props are passed to the `BookcaseCard` component.

- Console output improvement:
  * Changed the log statement to be more descriptive when fetching bookcases.

- Prop handling update:
  * Updated the `zone` and `identifier` props for `BookcaseCard` to use direct properties (`zone` and `index`) from the `bookcase` object instead of splitting the `bookcaseLabel` string.
---

Previously, the zone and identifier values were derived by splitting the bookcaseLabel string on ":" (e.g. "A:1"), which was fragile and coupled the UI to a specific label format.

Updated to use the dedicated `zone` and `index` fields returned directly from the API response, making the data binding more explicit and resilient to label format changes.

Also improved the fetch debug log to include a descriptive prefix ("Fetched bookcases:") for easier identification in the console.