### PR TITLE
Pass bookcase context through shelf navigation

### DIFF
--- a/src/pages/bookcase/AddBookcasePage.tsx
+++ b/src/pages/bookcase/AddBookcasePage.tsx
@@ -31,6 +31,12 @@ function AddBookcasePage() {
 				shelfCount: shelfCount,
 				shelfCapacity: shelfCapacity,
 			}),
+		}).then((response) => {
+			if (response.ok) {
+				console.log("Bookcase created successfully.");
+			} else {
+				console.log("Failed to create bookcase.");
+			}
 		});
 	}
 

--- a/src/pages/bookcase/ViewBookcasesPage.tsx
+++ b/src/pages/bookcase/ViewBookcasesPage.tsx
@@ -50,7 +50,7 @@ function ViewBookcasesPage() {
 						<Link
 							to={`/bookshelves/view/${bookcase.bookcaseId}`}
 							key={bookcase.bookcaseId}
-							state={{ bookcaseLocation: bookcase?.location, bookcaseLabel: bookcase?.bookcaseLabel }}
+							state={{ bookcaseLocation: bookcase?.location, index: bookcase?.index, bookcaseZone: bookcase?.zone, bookcaseIndex: bookcase?.index}}
 						>
 							<BookcaseCard
 								key={bookcase.bookcaseId}

--- a/src/pages/bookshelf/ViewBookshelvesPage.tsx
+++ b/src/pages/bookshelf/ViewBookshelvesPage.tsx
@@ -20,7 +20,7 @@ function ViewBookshelvesPage() {
 		})
 			.then((response) => response.json())
 			.then((data) => {
-				console.log(data);
+				console.log("Fetched bookshelves data: ", data);
 				setBookshelves(data);
 			});
 	}
@@ -35,7 +35,7 @@ function ViewBookshelvesPage() {
 			<section className=" ml-175px mr-175">
 				<div className="flex align-itms-ctr  p-20 mb-50">
 					<div>
-						<h1 className="blu">{location.state?.bookcaseLocation} :: {location.state?.bookcaseLabel} :: Bookshelves</h1>
+						<h1 className="blu">{location.state?.bookcaseLocation} :: {location.state?.bookcaseZone }  {location.state?.bookcaseIndex} :: Bookshelves</h1>
 						<p>Pick a bookshelf to see what's on each shelf.</p>
 					</div>
 				</div>
@@ -45,14 +45,14 @@ function ViewBookshelvesPage() {
 						<Link
 							to={`/bookshelves/view/shelf/${bookshelf.shelfId}`}
 							key={bookshelf.shelfId}
-							state={{ bookshelfLocation: location.state.bookcaseLocation, shelfLabel: bookshelf.shelfLabel, bookcaseLabel: bookshelf.bookcaseLabel }}
+							state={{ bookshelfLocation: location.state.bookcaseLocation, shelfLabel: bookshelf.shelfLabel, bookcaseZone: location.state.bookcaseZone, bookcaseIndex: location.state.bookcaseIndex }}
 						>
 							<BookcaseCard
 								key={bookshelf.shelfId}
 								location={bookshelf?.shelfLabel}
 								capacity={bookshelf?.bookCapacity}
-								zone={bookshelf?.bookcaseLabel.split(":")[0]}
-								identifier={bookshelf?.bookcaseLabel.split(":")[1]}
+								zone={location.state?.bookcaseZone}
+								identifier={location.state?.bookcaseIndex}
 								placed={bookshelf?.bookCount}
 							></BookcaseCard>
 						</Link>

--- a/src/pages/bookshelf/ViewShelfPage.tsx
+++ b/src/pages/bookshelf/ViewShelfPage.tsx
@@ -36,7 +36,7 @@ function ViewShelfPage() {
 			<section className=" ml-175px mr-175">
 				<div className="flex align-itms-ctr  p-20 mb-50">
 					<div>
-						<h1 className="blu"> {location.state?.bookshelfLocation} :: {location.state?.bookcaseLabel} :: Shelf {shelfId}</h1>
+						<h1 className="blu"> {location.state?.bookshelfLocation} :: {location.state?.bookcaseZone} {location.state?.bookcaseIndex} :: Shelf {shelfId}</h1>
 						<p>Pick a book from the shelf.</p>
 					</div>
 


### PR DESCRIPTION
This pull request updates the way bookcase and bookshelf location data is passed and displayed throughout the bookcase and bookshelf-related pages. The changes ensure more consistent and descriptive information is shown to users and passed between components, especially regarding bookcase zones and indices. Additionally, some minor improvements to logging have been made.

**Improvements to data passing and display:**

* Updated the state passed via `Link` components in both `ViewBookcasesPage` and `ViewBookshelvesPage` to include `bookcaseZone` and `bookcaseIndex`, ensuring downstream pages receive more detailed context about the selected bookcase. [[1]](diffhunk://#diff-78c208650b9d09aafe4494c1551a1fd45bcacb99daa46dba1a432e92ecd09ff5L53-R53) [[2]](diffhunk://#diff-ce43046300937de4943b2151040de982e34610b0bec3f1d7e4044a05021d6c4eL48-R55)
* Modified the headings in `ViewBookshelvesPage` and `ViewShelfPage` to display `bookcaseZone` and `bookcaseIndex` instead of the previous `bookcaseLabel`, providing clearer and more relevant information to users. [[1]](diffhunk://#diff-ce43046300937de4943b2151040de982e34610b0bec3f1d7e4044a05021d6c4eL38-R38) [[2]](diffhunk://#diff-fd46ccb6de1c71ec86269ebcc172b0040db8eef406df1223d9815b414a72d820L39-R39)

**User feedback and logging improvements:**

* Added success/failure logging in the `AddBookcasePage` to inform the user when a bookcase is created or if the operation fails.
* Improved the bookshelf data fetch log message in `ViewBookshelvesPage` for clarity.